### PR TITLE
chore(workflow): set engines to `"npm": "^9.0.0"`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,10 @@
         "@stickyjs/prettier": "1.0.0",
         "lerna": "^6.6.2",
         "turbo": "^1.10.3"
+      },
+      "engines": {
+        "node": "^18.0.0",
+        "npm": "^9.5.2"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     "lerna": "^6.6.2",
     "turbo": "^1.10.3"
   },
-  "packageManager": "npm@9.5.2",
+  "packageManager": "npm@9.5.1",
   "engines": {
     "node": "^18.0.0",
-    "npm": "^9.5.2"
+    "npm": "^9.0.0"
   }
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

As per title, so that it is more flexible.