### PR TITLE
feat(codeblock): codeblock with language selector

### DIFF
--- a/packages/contented-example/docs/04-markdown.md
+++ b/packages/contented-example/docs/04-markdown.md
@@ -290,6 +290,41 @@ const b: number = 2;
 
 #### Codeblock with Language Selector
 
-:::codeblock-group
+::::codeblock-group
+:::codeblock-header{filename="example.ts" language="TypeScript"}
+
+```ts
+const a: number = 1;
+const b: number = 2;
+```
 
 :::
+:::codeblock-header{filename="example.js" language="JavaScript"}
+
+```js
+const a = 1;
+const b = 2;
+```
+
+:::
+::::
+
+````txt
+::::codeblock-group
+
+:::codeblock-header{filename="example.ts" language="TypeScript"}
+```ts
+const a: number = 1;
+const b: number = 2;
+```
+:::
+
+:::codeblock-header{filename="example.js" language="JavaScript"}
+```js
+const a = 1;
+const b = 2;
+```
+:::
+
+::::
+````

--- a/packages/contented-preview/src/pages/[type]/[[...slug]].page.jsx
+++ b/packages/contented-preview/src/pages/[type]/[[...slug]].page.jsx
@@ -49,8 +49,36 @@ export default function IndexPage({ content, sections }) {
 
   mermaid.initialize({ theme, startOnLoad: false });
 
+  function setCodeblockGroupLanguage(language) {
+    function getLanguageMetadata(element) {
+      const dataGroups = element.querySelectorAll('nav')[0]?.getAttribute('data-groups');
+      if (!dataGroups) {
+        return;
+      }
+      const parsed = JSON.parse(dataGroups);
+      return parsed.find((group) => group.language === language) ?? parsed[0];
+    }
+
+    document.querySelectorAll('.prose div.codeblock-group').forEach((codeblockGroup) => {
+      const group = getLanguageMetadata(codeblockGroup);
+      if (!group) {
+        return;
+      }
+
+      codeblockGroup.querySelectorAll('.codeblock-language-selected')[0].innerHTML = group.language;
+      codeblockGroup.querySelectorAll('.codeblock-filename')[0].innerHTML = group.filename;
+      codeblockGroup.querySelectorAll('.codeblock-header').forEach((header) => {
+        header.style.display = header.getAttribute('data-language') !== language ? 'none' : 'block';
+      });
+    });
+  }
+
   useEffect(() => {
     mermaid.init();
+
+    document.querySelectorAll('.codeblock-language-options button').forEach((button) => {
+      button.onclick = () => setCodeblockGroupLanguage(button.innerHTML);
+    });
   }, [router.asPath, theme]);
 
   return (

--- a/packages/contented-preview/src/pages/_components/ContentNavigation.jsx
+++ b/packages/contented-preview/src/pages/_components/ContentNavigation.jsx
@@ -45,10 +45,10 @@ export default function ContentNavigation({ sections, className }) {
                   const isCurrentPath = linkPath === router.asPath || router.asPath + '/' === linkPath;
 
                   return (
-                    <li key={link.fileId} className="relative">
+                    <li key={link.fileId} className="relative flex h-6 items-center">
                       <Link
                         href={linkPath}
-                        className={clsx({
+                        className={clsx('truncate', {
                           'block w-full cursor-pointer truncate pl-3.5 before:pointer-events-none before:absolute before:inset-y-0 before:-left-1 before:w-1':
                             folderName,
                           'text-primary-500 before:bg-primary-500 font-semibold': isCurrentPath,

--- a/packages/contented-preview/src/styles/prose.css
+++ b/packages/contented-preview/src/styles/prose.css
@@ -102,16 +102,54 @@
   --shiki-token-link: #c9d1d9;
 }
 
-.prose .codeblock-header header {
+.prose .codeblock-header header,
+.prose .codeblock-group nav {
   @apply rounded-t-[6px] border;
   @apply border-slate-200/70 dark:border-slate-700/70;
-  @apply bg-slate-100/50 px-4 py-2.5 dark:bg-[#0d1117];
+  @apply h-[40px] bg-slate-100/50 px-4 dark:bg-[#0d1117];
   @apply flex items-center justify-between;
   @apply text-sm text-slate-500 dark:text-slate-400;
 }
 
 .prose .codeblock-header .rehype-shiki pre.css-variable {
   @apply mt-0 rounded-t-none border-t-0;
+}
+
+.prose .codeblock-group .codeblock-header header {
+  @apply hidden;
+}
+
+.prose .codeblock-group nav button.codeblock-language-selected {
+  @apply cursor-pointer;
+  @apply -mr-2.5 rounded px-2.5 py-1;
+  @apply hover:text-slate-700 dark:hover:text-slate-300;
+  @apply hover:bg-slate-200/50 dark:hover:bg-slate-700/50;
+}
+
+.prose .codeblock-group nav span.codeblock-language {
+  @apply relative;
+}
+
+.codeblock-language-options {
+  @apply hidden;
+  @apply absolute -right-6 -top-6 p-6;
+}
+
+.codeblock-language-options div {
+  @apply rounded p-1.5;
+  @apply bg-white shadow-lg dark:bg-slate-800;
+  @apply flex flex-col;
+}
+.codeblock-language-options div > button {
+  @apply cursor-pointer;
+  @apply rounded px-3 py-1;
+  @apply hover:text-slate-700 dark:hover:text-slate-300;
+  @apply hover:bg-slate-200/50 dark:hover:bg-slate-900/50;
+}
+
+button.codeblock-language-selected:focus + div.codeblock-language-options,
+div.codeblock-language-options:hover {
+  @apply flex;
 }
 
 .prose pre code {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

<img width="678" alt="image" src="https://github.com/levaintech/contented/assets/4266087/aa4b048a-8066-4d80-8f6e-2b4e1ccf24a9">

````md
::::codeblock-group
:::codeblock-header{filename="example.ts" language="TypeScript"}
```ts
const a: number = 1;
const b: number = 2;
```
:::
:::codeblock-header{filename="example.js" language="JavaScript"}
```js
const a = 1;
const b = 2;
```
:::
::::
````