### PR TITLE
chore(contented-preview): set text-left for "codeblock-language-options button"

### DIFF
--- a/packages/contented-preview/src/styles/prose.css
+++ b/packages/contented-preview/src/styles/prose.css
@@ -149,6 +149,7 @@
 .codeblock-language-options div > button {
   @apply cursor-pointer;
   @apply rounded px-3 py-1;
+  @apply text-left;
   @apply hover:text-slate-700 dark:hover:text-slate-300;
   @apply hover:bg-slate-200/50 dark:hover:bg-slate-900/50;
 }


### PR DESCRIPTION
#### What this PR does / why we need it:

As per title for alignment.