### PR TITLE
chore(contented-pipeline-md): parse `%20` as space

### DIFF
--- a/packages/contented-pipeline-md/fixtures/20-Heading/40-Section Title/200-DeepLink.md
+++ b/packages/contented-pipeline-md/fixtures/20-Heading/40-Section Title/200-DeepLink.md
@@ -1,0 +1,3 @@
+# DeepLinke
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla ege.

--- a/packages/contented-pipeline-md/fixtures/RemarkFrontmatter.md
+++ b/packages/contented-pipeline-md/fixtures/RemarkFrontmatter.md
@@ -1,0 +1,5 @@
+# Remark Frontmatter
+
+This is a test file with frontmatter where `title` and `description` will automatically be extracted if they are
+present and not explicitly set in the `---` configuration. This is useful for SEO purposes where descriptions and
+titles are important but not always explicitly set in the markdown frontmatter.

--- a/packages/contented-pipeline-md/fixtures/RemarkLink.md
+++ b/packages/contented-pipeline-md/fixtures/RemarkLink.md
@@ -1,4 +1,13 @@
+# `RemarkLink.ts`
+
+`RemarkLink.ts` will automatically link to other markdown files in your repository.
+
+## Test Links
+
 - [20-Heading/100-RemarkLinked.md](20-Heading/100-RemarkLinked.md)
 - [01-RemarkLinked.md](01-RemarkLinked.md)
 - [RemarkLink.md](RemarkLink.md)
 - [Contented](https://contented.dev)
+- [20-Heading/100-RemarkLinked.md](./20-Heading/100-RemarkLinked.md)
+- [20-Heading/40-Section Title/200-DeepLink.md](./20-Heading/40-Section%20Title/200-DeepLink.md)
+- [01-RemarkLinked.md](./01-RemarkLinked.md)

--- a/packages/contented-pipeline-md/src/plugins/RemarkFrontmatter.unit.ts
+++ b/packages/contented-pipeline-md/src/plugins/RemarkFrontmatter.unit.ts
@@ -1,0 +1,35 @@
+import { join } from 'node:path';
+
+import { MarkdownPipeline } from '../MarkdownPipeline';
+
+const rootPath = join(__dirname, '../../fixtures');
+
+const pipeline = new MarkdownPipeline(__dirname, {
+  type: 'Markdown',
+  pattern: ['/20-Heading/*.md', '/01-RemarkLinked.md', '/RemarkLink.md'],
+  processor: 'md',
+});
+
+beforeAll(async () => {
+  await pipeline.init();
+});
+
+it('should process RemarkFrontmatter.md', async () => {
+  const content = await pipeline.process(rootPath, 'RemarkFrontmatter.md');
+  expect(content).toStrictEqual([
+    {
+      type: 'Markdown',
+      fields: {
+        title: 'Remark Frontmatter',
+        description:
+          'This is a test file with frontmatter where title and description will automatically be extracted if they are present and not explicitly set in the --- configuration. This is useful for SEO purposes where descriptions and titles are important but n...',
+      },
+      headings: expect.any(Array),
+      sections: [],
+      path: '/remark-frontmatter',
+      fileId: expect.stringMatching(/[0-f]{64}/),
+      modifiedDate: expect.any(Number),
+      html: expect.any(String),
+    },
+  ]);
+});

--- a/packages/contented-pipeline-md/src/plugins/RemarkLink.ts
+++ b/packages/contented-pipeline-md/src/plugins/RemarkLink.ts
@@ -31,7 +31,7 @@ function visitLink(file: VFile): (node: Link) => void {
       );
       const parsedPath = parsePath(join(pipelineDir, contented.filePath));
       const linkedFilePath = join(pipelineDir, path);
-      const relativePath = relative(parsedPath.dir, linkedFilePath);
+      const relativePath = relative(parsedPath.dir, linkedFilePath).replaceAll('%20', ' ');
       node.url = contented.contentedPipeline.getSanitizedPath(relativePath);
     } else {
       node.url = contented.contentedPipeline.getSanitizedPath(path);

--- a/packages/contented-pipeline-md/src/plugins/RemarkLink.unit.ts
+++ b/packages/contented-pipeline-md/src/plugins/RemarkLink.unit.ts
@@ -20,21 +20,15 @@ it('should process RemarkLink.md', async () => {
     {
       type: 'Markdown',
       fields: {
-        description: '20-Heading/100-RemarkLinked.md',
-        title: undefined,
+        title: 'RemarkLink.ts',
+        description: 'RemarkLink.ts will automatically link to other markdown files in your repository.',
       },
-      headings: [],
-      path: '/remark-link',
+      headings: expect.any(Array),
       sections: [],
+      path: '/remark-link',
       fileId: expect.stringMatching(/[0-f]{64}/),
       modifiedDate: expect.any(Number),
-      html:
-        '<nav class="toc"><ol class="toc-level toc-level-1"></ol></nav><ul>\n' +
-        '<li><a href="heading/remark-linked">20-Heading/100-RemarkLinked.md</a></li>\n' +
-        '<li><a href="remark-linked">01-RemarkLinked.md</a></li>\n' +
-        '<li><a href="remark-link">RemarkLink.md</a></li>\n' +
-        '<li><a href="https://contented.dev" target="_blank" rel="nofollow">Contented</a></li>\n' +
-        '</ul>',
+      html: '<nav class="toc"><ol class="toc-level toc-level-1"><li class="toc-item toc-item-h1"><a class="toc-link toc-link-h1" href="#remarklinkts">RemarkLink.ts</a><ol class="toc-level toc-level-2"><li class="toc-item toc-item-h2"><a class="toc-link toc-link-h2" href="#test-links">Test Links</a></li></ol></li></ol></nav><h1 id="remarklinkts"><a aria-hidden="true" tabindex="-1" href="#remarklinkts"><span class="icon icon-link"></span></a><code>RemarkLink.ts</code></h1>\n<p><code>RemarkLink.ts</code> will automatically link to other markdown files in your repository.</p>\n<h2 id="test-links"><a aria-hidden="true" tabindex="-1" href="#test-links"><span class="icon icon-link"></span></a>Test Links</h2>\n<ul>\n<li><a href="heading/remark-linked">20-Heading/100-RemarkLinked.md</a></li>\n<li><a href="remark-linked">01-RemarkLinked.md</a></li>\n<li><a href="remark-link">RemarkLink.md</a></li>\n<li><a href="https://contented.dev" target="_blank" rel="nofollow">Contented</a></li>\n<li><a href="heading/remark-linked">20-Heading/100-RemarkLinked.md</a></li>\n<li><a href="heading/section-title/deep-link">20-Heading/40-Section Title/200-DeepLink.md</a></li>\n<li><a href="remark-linked">01-RemarkLinked.md</a></li>\n</ul>',
     },
   ]);
 });


### PR DESCRIPTION
#### What this PR does / why we need it:

Parse `%20` as space for `RemarkLink.ts`, also, add test for `truncate`.