### PR TITLE
chore(contented-preview): remove table first-child mt and last-child mb

### DIFF
--- a/packages/contented-preview/src/styles/prose.css
+++ b/packages/contented-preview/src/styles/prose.css
@@ -62,6 +62,14 @@
   table-layout: fixed;
 }
 
+.prose table tr :is(th, td) :first-child {
+  @apply mt-0;
+}
+
+.prose table tr :is(th, td) :last-child {
+  @apply mb-0;
+}
+
 .prose .mermaid {
   @apply rounded-[6px] p-6;
   @apply flex items-center justify-center;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Similar to `.admonitions`, the tr should influence padding instead of content to allow multiline string rendering.