### PR TITLE
chore(contented-processor): pipeline.type to support `^[a-zA-Z_$][\w$]*$`

### DIFF
--- a/packages/contented-processor/src/ContentedProcessor.ts
+++ b/packages/contented-processor/src/ContentedProcessor.ts
@@ -39,9 +39,9 @@ export class ContentedProcessor {
     config.outDir = config.outDir ?? './.contented';
     config.pipelines.forEach((pipeline) => {
       pipeline.type = pipeline.type ?? 'Docs';
-      if (pipeline.type.match(/[^a-zA-Z]/g)) {
+      if (!pipeline.type.match(/^[a-zA-Z_$][\w$]*$/)) {
         throw new Error(
-          'Due to codegen, pipeline.type must be a string with allowed characters within the range of [a-zA-Z].',
+          'Due to codegen, pipeline.type must be a string with allowed characters within the range of ^[a-zA-Z_$][\\w$]*$.',
         );
       }
 

--- a/packages/contented-processor/src/ContentedProcessor.unit.ts
+++ b/packages/contented-processor/src/ContentedProcessor.unit.ts
@@ -418,8 +418,24 @@ describe('validation', () => {
       ],
     };
     expect(() => new ContentedProcessor(config)).toThrow(
-      'Due to codegen, pipeline.type must be a string with allowed characters within the range of [a-zA-Z].',
+      'Due to codegen, pipeline.type must be a string with allowed characters within the range of ^[a-zA-Z_$][\\w$]*$.',
     );
+  });
+
+  it('should allow type.name with _', async () => {
+    const config: Config = {
+      rootDir: './fixtures',
+      outDir: './.contented',
+      pipelines: [
+        {
+          type: '_type',
+          pattern: '**/*.md',
+          processor: 'md',
+        },
+      ],
+    };
+
+    expect(() => new ContentedProcessor(config)).not.toThrow();
   });
 });
 


### PR DESCRIPTION
#### What this PR does / why we need it:

As per title.

#### Which issue(s) will this PR fix?:
